### PR TITLE
Clean up ID collision fix comment in dashboard.py

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -93,7 +93,7 @@ while True:
                 height=600
             )
             
-            # FIX: Add a unique key based on time to prevent ID collisions
+            # Add a unique key based on time to prevent ID collisions during live updates
             unique_key = f"chart_{time.time()}"
             st.plotly_chart(fig, use_container_width=True, key=unique_key)
             


### PR DESCRIPTION
The task was to verify the implementation of a unique key based on time to prevent ID collisions in the dashboard and clean up the associated comment. 

Upon investigation, I found that `unique_key = f"chart_{time.time()}"` was already implemented in `dashboard.py`. I have updated the comment to remove the "FIX:" prefix and clarified that it prevents collisions during live updates. 

Changes:
- Modified `dashboard.py`: Updated comment on line 96.
- Verified syntax correctness of `dashboard.py`.

---
*PR created automatically by Jules for task [17445965435153539089](https://jules.google.com/task/17445965435153539089) started by @m-jonas*